### PR TITLE
fix(theme): 修复 Android 路由返回时的 ink 动画残留问题

### DIFF
--- a/lib/ui/core/theme.dart
+++ b/lib/ui/core/theme.dart
@@ -18,6 +18,14 @@ abstract final class AppTheme {
   static ThemeData lightTheme = ThemeData(
     colorScheme: _lightColorScheme,
     useMaterial3: true,
+    pageTransitionsTheme: const PageTransitionsTheme(
+      builders: <TargetPlatform, PageTransitionsBuilder>{
+        TargetPlatform.android: ZoomPageTransitionsBuilder(
+          // 修复路由返回时的 ink 动画残留问题
+          allowEnterRouteSnapshotting: false,
+        ),
+      },
+    ),
     appBarTheme: const AppBarTheme(
       centerTitle: false,
     ),
@@ -32,6 +40,13 @@ abstract final class AppTheme {
   static ThemeData darkTheme = ThemeData(
     colorScheme: _darkColorScheme,
     useMaterial3: true,
+    pageTransitionsTheme: const PageTransitionsTheme(
+      builders: <TargetPlatform, PageTransitionsBuilder>{
+        TargetPlatform.android: ZoomPageTransitionsBuilder(
+          allowEnterRouteSnapshotting: false,
+        ),
+      },
+    ),
     appBarTheme: const AppBarTheme(
       centerTitle: false,
     ),


### PR DESCRIPTION
添加 pageTransitionsTheme 配置，设置 allowEnterRouteSnapshotting 为 false 以解决动画残留问题