### PR TITLE
fix: 修复 FAB 滚动隐藏功能在页面切换后失效的问题

### DIFF
--- a/lib/routing/router.dart
+++ b/lib/routing/router.dart
@@ -70,15 +70,6 @@ GoRouter router(SettingsRepository settingsRepository) => GoRouter(
               final title =
                   _getTitleForRoute(state.fullPath ?? state.matchedLocation);
 
-              // 检查是否为书签列表页面，需要显示FAB
-              final isBookmarkListRoute = [
-                Routes.dailyRead,
-                Routes.unarchived,
-                Routes.reading,
-                Routes.archived,
-                Routes.marked,
-              ].contains(state.fullPath ?? state.matchedLocation);
-
               // 从设置页返回，跳转首页
               if ((state.fullPath ?? state.matchedLocation) ==
                   Routes.settings) {
@@ -95,9 +86,22 @@ GoRouter router(SettingsRepository settingsRepository) => GoRouter(
                 );
               }
 
+              // 书签列表页面不被 MainLayout 包装，它们自己管理 UI
+              final selfManagedRoutes = [
+                Routes.dailyRead,
+                Routes.unarchived,
+                Routes.reading,
+                Routes.archived,
+                Routes.marked,
+              ];
+
+              if (selfManagedRoutes
+                  .contains(state.fullPath ?? state.matchedLocation)) {
+                return child;
+              }
+
               return MainLayout(
                 title: title,
-                showFab: isBookmarkListRoute,
                 child: child,
               );
             },

--- a/lib/ui/bookmarks/widget/archived_screen.dart
+++ b/lib/ui/bookmarks/widget/archived_screen.dart
@@ -1,22 +1,48 @@
 import 'package:flutter/material.dart';
 import 'package:readeck_app/ui/bookmarks/view_models/bookmarks_viewmodel.dart';
 import 'package:readeck_app/ui/bookmarks/widget/bookmark_list_screen.dart';
+import 'package:readeck_app/ui/core/main_layout.dart';
 
-class ArchivedScreen extends StatelessWidget {
+class ArchivedScreen extends StatefulWidget {
   const ArchivedScreen({super.key, required this.viewModel});
 
   final ArchivedViewmodel viewModel;
 
   @override
+  State<ArchivedScreen> createState() => _ArchivedScreenState();
+}
+
+class _ArchivedScreenState extends State<ArchivedScreen> {
+  late final ScrollController _scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return BookmarkListScreen(
-      viewModel: viewModel,
-      texts: const BookmarkListTexts(
-        loadingText: '正在加载已归档书签',
-        errorMessage: '已归档书签加载失败',
-        emptyIcon: Icons.archive_outlined,
-        emptyTitle: '暂无已归档书签',
-        emptySubtitle: '归档的书签将在这里显示',
+    return MainLayout(
+      title: '已归档',
+      showFab: true,
+      scrollController: _scrollController,
+      child: BookmarkListScreen(
+        viewModel: widget.viewModel,
+        scrollController: _scrollController,
+        texts: const BookmarkListTexts(
+          loadingText: '正在加载已归档书签',
+          errorMessage: '已归档书签加载失败',
+          emptyIcon: Icons.archive_outlined,
+          emptyTitle: '暂无已归档书签',
+          emptySubtitle: '归档的书签将在这里显示',
+        ),
       ),
     );
   }

--- a/lib/ui/bookmarks/widget/bookmark_list_screen.dart
+++ b/lib/ui/bookmarks/widget/bookmark_list_screen.dart
@@ -10,7 +10,6 @@ import 'package:readeck_app/ui/core/ui/loading.dart';
 import 'package:readeck_app/ui/bookmarks/view_models/bookmarks_viewmodel.dart';
 import 'package:readeck_app/utils/network_error_exception.dart';
 import 'package:readeck_app/ui/core/ui/snack_bar_helper.dart';
-import 'package:readeck_app/ui/core/main_layout.dart';
 
 /// 书签列表页面的文案配置
 class BookmarkListTexts {
@@ -45,10 +44,12 @@ class BookmarkListScreen<T extends BaseBookmarksViewmodel>
     super.key,
     required this.viewModel,
     required this.texts,
+    this.scrollController,
   });
 
   final T viewModel;
   final BookmarkListTexts texts;
+  final ScrollController? scrollController;
 
   @override
   State<BookmarkListScreen<T>> createState() => _BookmarkListScreenState<T>();
@@ -92,37 +93,18 @@ class _BookmarkListScreenState<T extends BaseBookmarksViewmodel>
   void didChangeDependencies() {
     super.didChangeDependencies();
 
-    // 只有在没有外部提供ScrollController时才创建自己的
-    if (_scrollController == null) {
-      _scrollController = ScrollController();
-      _scrollController?.addListener(_onScroll);
-
-      // 延迟到下一帧更新Provider，避免在build过程中触发rebuild
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) {
-          try {
-            final provider = context.read<ScrollControllerProvider?>();
-            provider?.setScrollController(_scrollController);
-          } catch (e) {
-            // 在测试环境中可能会失败，忽略
-          }
-        }
-      });
-    }
+    // 使用外部提供的 ScrollController 或创建自己的
+    _scrollController ??= widget.scrollController ?? ScrollController();
+    _scrollController?.addListener(_onScroll);
   }
 
   @override
   void dispose() {
-    // 清除Provider中的ScrollController引用
-    try {
-      final provider = context.read<ScrollControllerProvider?>();
-      provider?.setScrollController(null);
-    } catch (e) {
-      // 在测试或context已失效时忽略错误
-    }
-
     _scrollController?.removeListener(_onScroll);
-    _scrollController?.dispose();
+    // 只有自己创建的 ScrollController 才需要 dispose
+    if (widget.scrollController == null) {
+      _scrollController?.dispose();
+    }
     _deleteSuccessSubscription.cancel();
     super.dispose();
   }

--- a/lib/ui/bookmarks/widget/marked_screen.dart
+++ b/lib/ui/bookmarks/widget/marked_screen.dart
@@ -1,22 +1,48 @@
 import 'package:flutter/material.dart';
 import 'package:readeck_app/ui/bookmarks/view_models/bookmarks_viewmodel.dart';
 import 'package:readeck_app/ui/bookmarks/widget/bookmark_list_screen.dart';
+import 'package:readeck_app/ui/core/main_layout.dart';
 
-class MarkedScreen extends StatelessWidget {
+class MarkedScreen extends StatefulWidget {
   const MarkedScreen({super.key, required this.viewModel});
 
   final MarkedViewmodel viewModel;
 
   @override
+  State<MarkedScreen> createState() => _MarkedScreenState();
+}
+
+class _MarkedScreenState extends State<MarkedScreen> {
+  late final ScrollController _scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return BookmarkListScreen(
-      viewModel: viewModel,
-      texts: const BookmarkListTexts(
-        loadingText: '正在加载喜爱书签',
-        errorMessage: '喜爱书签加载失败',
-        emptyIcon: Icons.favorite_outline,
-        emptyTitle: '暂无喜爱书签',
-        emptySubtitle: '标记为喜爱的书签将在这里显示',
+    return MainLayout(
+      title: '标记喜爱',
+      showFab: true,
+      scrollController: _scrollController,
+      child: BookmarkListScreen(
+        viewModel: widget.viewModel,
+        scrollController: _scrollController,
+        texts: const BookmarkListTexts(
+          loadingText: '正在加载喜爱书签',
+          errorMessage: '喜爱书签加载失败',
+          emptyIcon: Icons.favorite_outline,
+          emptyTitle: '暂无喜爱书签',
+          emptySubtitle: '标记为喜爱的书签将在这里显示',
+        ),
       ),
     );
   }

--- a/lib/ui/bookmarks/widget/reading_screen.dart
+++ b/lib/ui/bookmarks/widget/reading_screen.dart
@@ -1,22 +1,48 @@
 import 'package:flutter/material.dart';
 import 'package:readeck_app/ui/bookmarks/view_models/bookmarks_viewmodel.dart';
 import 'package:readeck_app/ui/bookmarks/widget/bookmark_list_screen.dart';
+import 'package:readeck_app/ui/core/main_layout.dart';
 
-class ReadingScreen extends StatelessWidget {
+class ReadingScreen extends StatefulWidget {
   const ReadingScreen({super.key, required this.viewModel});
 
   final ReadingViewmodel viewModel;
 
   @override
+  State<ReadingScreen> createState() => _ReadingScreenState();
+}
+
+class _ReadingScreenState extends State<ReadingScreen> {
+  late final ScrollController _scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return BookmarkListScreen(
-      viewModel: viewModel,
-      texts: const BookmarkListTexts(
-        loadingText: '正在加载阅读中书签',
-        errorMessage: '阅读中书签加载失败',
-        emptyIcon: Icons.auto_stories_outlined,
-        emptyTitle: '暂无阅读中书签',
-        emptySubtitle: '下拉刷新或去Readeck开始阅读书签',
+    return MainLayout(
+      title: '阅读中',
+      showFab: true,
+      scrollController: _scrollController,
+      child: BookmarkListScreen(
+        viewModel: widget.viewModel,
+        scrollController: _scrollController,
+        texts: const BookmarkListTexts(
+          loadingText: '正在加载阅读中书签',
+          errorMessage: '阅读中书签加载失败',
+          emptyIcon: Icons.auto_stories_outlined,
+          emptyTitle: '暂无阅读中书签',
+          emptySubtitle: '下拉刷新或去Readeck开始阅读书签',
+        ),
       ),
     );
   }

--- a/lib/ui/bookmarks/widget/unarchived_screen.dart
+++ b/lib/ui/bookmarks/widget/unarchived_screen.dart
@@ -1,22 +1,48 @@
 import 'package:flutter/material.dart';
 import 'package:readeck_app/ui/bookmarks/view_models/bookmarks_viewmodel.dart';
 import 'package:readeck_app/ui/bookmarks/widget/bookmark_list_screen.dart';
+import 'package:readeck_app/ui/core/main_layout.dart';
 
-class UnarchivedScreen extends StatelessWidget {
+class UnarchivedScreen extends StatefulWidget {
   const UnarchivedScreen({super.key, required this.viewModel});
 
   final UnarchivedViewmodel viewModel;
 
   @override
+  State<UnarchivedScreen> createState() => _UnarchivedScreenState();
+}
+
+class _UnarchivedScreenState extends State<UnarchivedScreen> {
+  late final ScrollController _scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return BookmarkListScreen(
-      viewModel: viewModel,
-      texts: const BookmarkListTexts(
-        loadingText: '正在加载未归档书签',
-        errorMessage: '未归档书签加载失败',
-        emptyIcon: Icons.inbox_outlined,
-        emptyTitle: '暂无未归档书签',
-        emptySubtitle: '下拉刷新或去Readeck添加新的书签',
+    return MainLayout(
+      title: '未读',
+      showFab: true,
+      scrollController: _scrollController,
+      child: BookmarkListScreen(
+        viewModel: widget.viewModel,
+        scrollController: _scrollController,
+        texts: const BookmarkListTexts(
+          loadingText: '正在加载未归档书签',
+          errorMessage: '未归档书签加载失败',
+          emptyIcon: Icons.inbox_outlined,
+          emptyTitle: '暂无未归档书签',
+          emptySubtitle: '下拉刷新或去Readeck添加新的书签',
+        ),
       ),
     );
   }

--- a/lib/ui/core/main_layout.dart
+++ b/lib/ui/core/main_layout.dart
@@ -4,28 +4,8 @@ import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:readeck_app/main_viewmodel.dart';
 import 'package:readeck_app/routing/routes.dart';
-import 'package:readeck_app/ui/core/ui/bookmark_list_fab.dart';
 import 'package:readeck_app/ui/settings/view_models/about_viewmodel.dart';
-
-/// ScrollController提供者，用于FAB和页面之间共享滚动控制器
-class ScrollControllerProvider extends ChangeNotifier {
-  ScrollController? _scrollController;
-
-  ScrollController? get scrollController => _scrollController;
-
-  void setScrollController(ScrollController? controller) {
-    if (_scrollController != controller) {
-      _scrollController = controller;
-      notifyListeners();
-    }
-  }
-
-  @override
-  void dispose() {
-    _scrollController = null;
-    super.dispose();
-  }
-}
+import 'package:readeck_app/ui/core/ui/bookmark_list_fab.dart';
 
 class MainLayout extends StatefulWidget {
   final Widget child;
@@ -35,6 +15,7 @@ class MainLayout extends StatefulWidget {
   final Widget? leading;
   final bool automaticallyImplyLeading;
   final Widget? floatingActionButton;
+  final ScrollController? scrollController;
   final bool showFab;
 
   const MainLayout({
@@ -46,6 +27,7 @@ class MainLayout extends StatefulWidget {
     this.leading,
     this.automaticallyImplyLeading = true,
     this.floatingActionButton,
+    this.scrollController,
     this.showFab = false,
   });
 
@@ -137,72 +119,63 @@ class _MainLayoutState extends State<MainLayout> {
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (context) => ScrollControllerProvider(),
-      child: Scaffold(
-        appBar: widget.appBar ??
-            (widget.title != null ||
-                    widget.actions != null ||
-                    widget.leading != null
-                ? AppBar(
-                    title: widget.title != null ? Text(widget.title!) : null,
-                    actions: widget.actions,
-                    leading: widget.leading,
-                    automaticallyImplyLeading: widget.automaticallyImplyLeading,
-                  )
-                : AppBar(
-                    automaticallyImplyLeading: widget.automaticallyImplyLeading,
-                    leading: Builder(
-                      builder: (context) {
-                        return IconButton(
-                          icon: const Icon(Icons.menu),
-                          onPressed: () {
-                            Scaffold.of(context).openDrawer();
-                          },
-                        );
-                      },
-                    ),
-                  )),
-        drawer: NavigationDrawer(
-          children: [
-            ListTile(
-              title: const Text('每日阅读'),
-              onTap: () => _navigateToRoute(context, Routes.dailyRead),
-            ),
-            ListTile(
-              title: const Text('未读'),
-              onTap: () => _navigateToRoute(context, Routes.unarchived),
-            ),
-            ListTile(
-              title: const Text('阅读中'),
-              onTap: () => _navigateToRoute(context, Routes.reading),
-            ),
-            ListTile(
-              title: const Text('已归档'),
-              onTap: () => _navigateToRoute(context, Routes.archived),
-            ),
-            ListTile(
-              title: const Text('收藏'),
-              onTap: () => _navigateToRoute(context, Routes.marked),
-            ),
-            ListTile(
-              title: const Text('设置'),
-              trailing: _hasUpdate ? const Badge() : null,
-              onTap: () => _navigateToRoute(context, Routes.settings),
-            ),
-          ],
-        ),
-        body: widget.child, // 显示当前路由的页面
-        floatingActionButton: widget.showFab
-            ? Consumer<ScrollControllerProvider>(
-                builder: (context, provider, child) {
-                  return BookmarkListFab(
-                    scrollController: provider.scrollController,
-                  );
-                },
-              )
-            : widget.floatingActionButton,
+    return Scaffold(
+      appBar: widget.appBar ??
+          (widget.title != null ||
+                  widget.actions != null ||
+                  widget.leading != null
+              ? AppBar(
+                  title: widget.title != null ? Text(widget.title!) : null,
+                  actions: widget.actions,
+                  leading: widget.leading,
+                  automaticallyImplyLeading: widget.automaticallyImplyLeading,
+                )
+              : AppBar(
+                  automaticallyImplyLeading: widget.automaticallyImplyLeading,
+                  leading: Builder(
+                    builder: (context) {
+                      return IconButton(
+                        icon: const Icon(Icons.menu),
+                        onPressed: () {
+                          Scaffold.of(context).openDrawer();
+                        },
+                      );
+                    },
+                  ),
+                )),
+      drawer: NavigationDrawer(
+        children: [
+          ListTile(
+            title: const Text('每日阅读'),
+            onTap: () => _navigateToRoute(context, Routes.dailyRead),
+          ),
+          ListTile(
+            title: const Text('未读'),
+            onTap: () => _navigateToRoute(context, Routes.unarchived),
+          ),
+          ListTile(
+            title: const Text('阅读中'),
+            onTap: () => _navigateToRoute(context, Routes.reading),
+          ),
+          ListTile(
+            title: const Text('已归档'),
+            onTap: () => _navigateToRoute(context, Routes.archived),
+          ),
+          ListTile(
+            title: const Text('收藏'),
+            onTap: () => _navigateToRoute(context, Routes.marked),
+          ),
+          ListTile(
+            title: const Text('设置'),
+            trailing: _hasUpdate ? const Badge() : null,
+            onTap: () => _navigateToRoute(context, Routes.settings),
+          ),
+        ],
       ),
+      body: widget.child, // 显示当前路由的页面
+      floatingActionButton: widget.showFab && widget.scrollController != null
+          ? BookmarkListFab(scrollController: widget.scrollController!)
+          : widget.floatingActionButton,
     );
   }
 }

--- a/lib/ui/core/ui/bookmark_list_fab.dart
+++ b/lib/ui/core/ui/bookmark_list_fab.dart
@@ -44,33 +44,25 @@ class _BookmarkListFabState extends State<BookmarkListFab>
 
     // 初始状态显示FAB
     _animationController.forward();
-
-    // 监听滚动事件
-    _attachScrollListener();
   }
 
   @override
   void didUpdateWidget(BookmarkListFab oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.scrollController != widget.scrollController) {
-      _detachScrollListener(oldWidget.scrollController);
-      _attachScrollListener();
+      // ScrollController 变化时重置状态
+      _lastScrollPosition = 0;
+      setState(() {
+        _isVisible = true;
+      });
+      _animationController.forward();
     }
   }
 
   @override
   void dispose() {
-    _detachScrollListener(widget.scrollController);
     _animationController.dispose();
     super.dispose();
-  }
-
-  void _attachScrollListener() {
-    widget.scrollController?.addListener(_onScroll);
-  }
-
-  void _detachScrollListener(ScrollController? controller) {
-    controller?.removeListener(_onScroll);
   }
 
   void _onScroll() {
@@ -83,10 +75,11 @@ class _BookmarkListFabState extends State<BookmarkListFab>
     final scrollDelta = currentScrollPosition - _lastScrollPosition;
 
     // 滚动阈值，避免微小滚动导致频繁切换
-    const scrollThreshold = 3.0;
+    const scrollThreshold = 5.0;
 
     // 如果滚动距离太小，忽略
     if (scrollDelta.abs() < scrollThreshold) {
+      _lastScrollPosition = currentScrollPosition;
       return;
     }
 
@@ -127,6 +120,12 @@ class _BookmarkListFabState extends State<BookmarkListFab>
 
   @override
   Widget build(BuildContext context) {
+    // 简单直接地绑定监听器
+    if (widget.scrollController != null) {
+      widget.scrollController!.removeListener(_onScroll);
+      widget.scrollController!.addListener(_onScroll);
+    }
+
     return ScaleTransition(
       scale: _animation,
       child: FloatingActionButton(

--- a/lib/ui/core/ui/bookmark_list_fab.dart
+++ b/lib/ui/core/ui/bookmark_list_fab.dart
@@ -44,23 +44,29 @@ class _BookmarkListFabState extends State<BookmarkListFab>
 
     // 初始状态显示FAB
     _animationController.forward();
+
+    // 监听滚动事件
+    widget.scrollController?.addListener(_onScroll);
   }
 
   @override
   void didUpdateWidget(BookmarkListFab oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.scrollController != widget.scrollController) {
-      // ScrollController 变化时重置状态
+      // 先解绑旧，再绑定新
+      oldWidget.scrollController?.removeListener(_onScroll);
+      widget.scrollController?.addListener(_onScroll);
+      // 重置滚动状态与动画
       _lastScrollPosition = 0;
-      setState(() {
-        _isVisible = true;
-      });
+      _isVisible = true;
       _animationController.forward();
     }
   }
 
   @override
   void dispose() {
+    // 解绑监听，防止内存泄漏与已销毁状态的 setState
+    widget.scrollController?.removeListener(_onScroll);
     _animationController.dispose();
     super.dispose();
   }
@@ -120,12 +126,6 @@ class _BookmarkListFabState extends State<BookmarkListFab>
 
   @override
   Widget build(BuildContext context) {
-    // 简单直接地绑定监听器
-    if (widget.scrollController != null) {
-      widget.scrollController!.removeListener(_onScroll);
-      widget.scrollController!.addListener(_onScroll);
-    }
-
     return ScaleTransition(
       scale: _animation,
       child: FloatingActionButton(

--- a/test/ui/bookmarks/widget/reading_screen_test.mocks.dart
+++ b/test/ui/bookmarks/widget/reading_screen_test.mocks.dart
@@ -6,13 +6,19 @@
 import 'dart:async' as _i7;
 import 'dart:ui' as _i8;
 
+import 'package:flutter/material.dart' as _i10;
 import 'package:flutter_command/flutter_command.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:mockito/src/dummies.dart' as _i12;
 import 'package:readeck_app/domain/models/bookmark/bookmark.dart' as _i6;
 import 'package:readeck_app/domain/models/bookmark_display_model/bookmark_display_model.dart'
     as _i4;
+import 'package:readeck_app/domain/models/update/update_info.dart' as _i13;
+import 'package:readeck_app/main_viewmodel.dart' as _i9;
 import 'package:readeck_app/ui/bookmarks/view_models/bookmarks_viewmodel.dart'
     as _i3;
+import 'package:readeck_app/ui/settings/view_models/about_viewmodel.dart'
+    as _i11;
 import 'package:readeck_app/utils/reading_stats_calculator.dart' as _i5;
 
 // ignore_for_file: type=lint
@@ -295,6 +301,212 @@ class MockReadingViewmodel extends _i1.Mock implements _i3.ReadingViewmodel {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+}
+
+/// A class which mocks [MainAppViewModel].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockMainAppViewModel extends _i1.Mock implements _i9.MainAppViewModel {
+  MockMainAppViewModel() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i10.ThemeMode get themeMode => (super.noSuchMethod(
+        Invocation.getter(#themeMode),
+        returnValue: _i10.ThemeMode.system,
+      ) as _i10.ThemeMode);
+
+  @override
+  _i7.Stream<String> get shareTextStream => (super.noSuchMethod(
+        Invocation.getter(#shareTextStream),
+        returnValue: _i7.Stream<String>.empty(),
+      ) as _i7.Stream<String>);
+
+  @override
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  void setPendingSharedText(String? text) => super.noSuchMethod(
+        Invocation.method(
+          #setPendingSharedText,
+          [text],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void clearPendingSharedText() => super.noSuchMethod(
+        Invocation.method(
+          #clearPendingSharedText,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void addListener(_i8.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void removeListener(_i8.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+}
+
+/// A class which mocks [AboutViewModel].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockAboutViewModel extends _i1.Mock implements _i11.AboutViewModel {
+  MockAboutViewModel() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i2.Command<dynamic, dynamic> get load => (super.noSuchMethod(
+        Invocation.getter(#load),
+        returnValue: _FakeCommand_0<dynamic, dynamic>(
+          this,
+          Invocation.getter(#load),
+        ),
+      ) as _i2.Command<dynamic, dynamic>);
+
+  @override
+  String get version => (super.noSuchMethod(
+        Invocation.getter(#version),
+        returnValue: _i12.dummyValue<String>(
+          this,
+          Invocation.getter(#version),
+        ),
+      ) as String);
+
+  @override
+  double get downloadProgress => (super.noSuchMethod(
+        Invocation.getter(#downloadProgress),
+        returnValue: 0.0,
+      ) as double);
+
+  @override
+  bool get isDownloading => (super.noSuchMethod(
+        Invocation.getter(#isDownloading),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  bool get isInstalling => (super.noSuchMethod(
+        Invocation.getter(#isInstalling),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  _i2.Command<_i13.UpdateInfo, void> get downloadAndInstallUpdateCommand =>
+      (super.noSuchMethod(
+        Invocation.getter(#downloadAndInstallUpdateCommand),
+        returnValue: _FakeCommand_0<_i13.UpdateInfo, void>(
+          this,
+          Invocation.getter(#downloadAndInstallUpdateCommand),
+        ),
+      ) as _i2.Command<_i13.UpdateInfo, void>);
+
+  @override
+  _i2.Command<_i13.UpdateInfo, String> get downloadUpdateCommand =>
+      (super.noSuchMethod(
+        Invocation.getter(#downloadUpdateCommand),
+        returnValue: _FakeCommand_0<_i13.UpdateInfo, String>(
+          this,
+          Invocation.getter(#downloadUpdateCommand),
+        ),
+      ) as _i2.Command<_i13.UpdateInfo, String>);
+
+  @override
+  _i2.Command<String, void> get installUpdateCommand => (super.noSuchMethod(
+        Invocation.getter(#installUpdateCommand),
+        returnValue: _FakeCommand_0<String, void>(
+          this,
+          Invocation.getter(#installUpdateCommand),
+        ),
+      ) as _i2.Command<String, void>);
+
+  @override
+  set load(_i2.Command<dynamic, dynamic>? _load) => super.noSuchMethod(
+        Invocation.setter(
+          #load,
+          _load,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  void addListener(_i8.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void removeListener(_i8.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
         ),
         returnValueForMissingStub: null,
       );

--- a/test/ui/daily_read/widgets/daily_read_screen_test.dart
+++ b/test/ui/daily_read/widgets/daily_read_screen_test.dart
@@ -9,18 +9,15 @@ import 'package:readeck_app/domain/models/bookmark/bookmark.dart';
 import 'package:readeck_app/domain/models/bookmark_display_model/bookmark_display_model.dart';
 import 'package:readeck_app/ui/daily_read/view_models/daily_read_viewmodel.dart';
 import 'package:readeck_app/ui/daily_read/widgets/daily_read_screen.dart';
-import 'package:readeck_app/ui/core/main_layout.dart';
 
 import 'daily_read_screen_test.mocks.dart';
 
 @GenerateNiceMocks([MockSpec<DailyReadViewModel>()])
 void main() {
   late MockDailyReadViewModel mockDailyReadViewModel;
-  late ScrollControllerProvider scrollControllerProvider;
 
   setUp(() {
     mockDailyReadViewModel = MockDailyReadViewModel();
-    scrollControllerProvider = ScrollControllerProvider();
 
     // Stub all other commands that might be accessed during build
     final mockOpenUrlCommand =
@@ -49,21 +46,10 @@ void main() {
         .thenReturn(null);
   });
 
-  tearDown(() {
-    scrollControllerProvider.dispose();
-  });
-
   Widget createWidgetUnderTest() {
     return MaterialApp(
-      home: MultiProvider(
-        providers: [
-          ChangeNotifierProvider<DailyReadViewModel>.value(
-            value: mockDailyReadViewModel,
-          ),
-          ChangeNotifierProvider<ScrollControllerProvider>.value(
-            value: scrollControllerProvider,
-          ),
-        ],
+      home: ChangeNotifierProvider<DailyReadViewModel>.value(
+        value: mockDailyReadViewModel,
         child: DailyReadScreen(viewModel: mockDailyReadViewModel),
       ),
     );

--- a/test/ui/daily_read/widgets/daily_read_screen_test.dart
+++ b/test/ui/daily_read/widgets/daily_read_screen_test.dart
@@ -9,15 +9,25 @@ import 'package:readeck_app/domain/models/bookmark/bookmark.dart';
 import 'package:readeck_app/domain/models/bookmark_display_model/bookmark_display_model.dart';
 import 'package:readeck_app/ui/daily_read/view_models/daily_read_viewmodel.dart';
 import 'package:readeck_app/ui/daily_read/widgets/daily_read_screen.dart';
+import 'package:readeck_app/main_viewmodel.dart';
+import 'package:readeck_app/ui/settings/view_models/about_viewmodel.dart';
 
 import 'daily_read_screen_test.mocks.dart';
 
-@GenerateNiceMocks([MockSpec<DailyReadViewModel>()])
+@GenerateNiceMocks([
+  MockSpec<DailyReadViewModel>(),
+  MockSpec<MainAppViewModel>(),
+  MockSpec<AboutViewModel>(),
+])
 void main() {
   late MockDailyReadViewModel mockDailyReadViewModel;
+  late MockMainAppViewModel mockMainAppViewModel;
+  late MockAboutViewModel mockAboutViewModel;
 
   setUp(() {
     mockDailyReadViewModel = MockDailyReadViewModel();
+    mockMainAppViewModel = MockMainAppViewModel();
+    mockAboutViewModel = MockAboutViewModel();
 
     // Stub all other commands that might be accessed during build
     final mockOpenUrlCommand =
@@ -44,12 +54,29 @@ void main() {
         .thenReturn(null);
     when(mockDailyReadViewModel.setNavigateToDetailCallback(any))
         .thenReturn(null);
+
+    // Mock MainAppViewModel
+    when(mockMainAppViewModel.shareTextStream)
+        .thenAnswer((_) => const Stream.empty());
+
+    // Mock AboutViewModel
+    when(mockAboutViewModel.updateInfo).thenReturn(null);
   });
 
   Widget createWidgetUnderTest() {
     return MaterialApp(
-      home: ChangeNotifierProvider<DailyReadViewModel>.value(
-        value: mockDailyReadViewModel,
+      home: MultiProvider(
+        providers: [
+          ChangeNotifierProvider<DailyReadViewModel>.value(
+            value: mockDailyReadViewModel,
+          ),
+          ChangeNotifierProvider<MainAppViewModel>.value(
+            value: mockMainAppViewModel,
+          ),
+          ChangeNotifierProvider<AboutViewModel>.value(
+            value: mockAboutViewModel,
+          ),
+        ],
         child: DailyReadScreen(viewModel: mockDailyReadViewModel),
       ),
     );

--- a/test/ui/daily_read/widgets/daily_read_screen_test.mocks.dart
+++ b/test/ui/daily_read/widgets/daily_read_screen_test.mocks.dart
@@ -6,13 +6,19 @@
 import 'dart:async' as _i8;
 import 'dart:ui' as _i6;
 
+import 'package:flutter/material.dart' as _i10;
 import 'package:flutter_command/flutter_command.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:mockito/src/dummies.dart' as _i12;
 import 'package:readeck_app/domain/models/bookmark/bookmark.dart' as _i7;
 import 'package:readeck_app/domain/models/bookmark_display_model/bookmark_display_model.dart'
     as _i4;
+import 'package:readeck_app/domain/models/update/update_info.dart' as _i13;
+import 'package:readeck_app/main_viewmodel.dart' as _i9;
 import 'package:readeck_app/ui/daily_read/view_models/daily_read_viewmodel.dart'
     as _i3;
+import 'package:readeck_app/ui/settings/view_models/about_viewmodel.dart'
+    as _i11;
 import 'package:readeck_app/utils/reading_stats_calculator.dart' as _i5;
 
 // ignore_for_file: type=lint
@@ -309,6 +315,231 @@ class MockDailyReadViewModel extends _i1.Mock
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+}
+
+/// A class which mocks [MainAppViewModel].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockMainAppViewModel extends _i1.Mock implements _i9.MainAppViewModel {
+  @override
+  _i10.ThemeMode get themeMode => (super.noSuchMethod(
+        Invocation.getter(#themeMode),
+        returnValue: _i10.ThemeMode.system,
+        returnValueForMissingStub: _i10.ThemeMode.system,
+      ) as _i10.ThemeMode);
+
+  @override
+  _i8.Stream<String> get shareTextStream => (super.noSuchMethod(
+        Invocation.getter(#shareTextStream),
+        returnValue: _i8.Stream<String>.empty(),
+        returnValueForMissingStub: _i8.Stream<String>.empty(),
+      ) as _i8.Stream<String>);
+
+  @override
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void setPendingSharedText(String? text) => super.noSuchMethod(
+        Invocation.method(
+          #setPendingSharedText,
+          [text],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void clearPendingSharedText() => super.noSuchMethod(
+        Invocation.method(
+          #clearPendingSharedText,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+}
+
+/// A class which mocks [AboutViewModel].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockAboutViewModel extends _i1.Mock implements _i11.AboutViewModel {
+  @override
+  _i2.Command<dynamic, dynamic> get load => (super.noSuchMethod(
+        Invocation.getter(#load),
+        returnValue: _FakeCommand_0<dynamic, dynamic>(
+          this,
+          Invocation.getter(#load),
+        ),
+        returnValueForMissingStub: _FakeCommand_0<dynamic, dynamic>(
+          this,
+          Invocation.getter(#load),
+        ),
+      ) as _i2.Command<dynamic, dynamic>);
+
+  @override
+  String get version => (super.noSuchMethod(
+        Invocation.getter(#version),
+        returnValue: _i12.dummyValue<String>(
+          this,
+          Invocation.getter(#version),
+        ),
+        returnValueForMissingStub: _i12.dummyValue<String>(
+          this,
+          Invocation.getter(#version),
+        ),
+      ) as String);
+
+  @override
+  double get downloadProgress => (super.noSuchMethod(
+        Invocation.getter(#downloadProgress),
+        returnValue: 0.0,
+        returnValueForMissingStub: 0.0,
+      ) as double);
+
+  @override
+  bool get isDownloading => (super.noSuchMethod(
+        Invocation.getter(#isDownloading),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get isInstalling => (super.noSuchMethod(
+        Invocation.getter(#isInstalling),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  _i2.Command<_i13.UpdateInfo, void> get downloadAndInstallUpdateCommand =>
+      (super.noSuchMethod(
+        Invocation.getter(#downloadAndInstallUpdateCommand),
+        returnValue: _FakeCommand_0<_i13.UpdateInfo, void>(
+          this,
+          Invocation.getter(#downloadAndInstallUpdateCommand),
+        ),
+        returnValueForMissingStub: _FakeCommand_0<_i13.UpdateInfo, void>(
+          this,
+          Invocation.getter(#downloadAndInstallUpdateCommand),
+        ),
+      ) as _i2.Command<_i13.UpdateInfo, void>);
+
+  @override
+  _i2.Command<_i13.UpdateInfo, String> get downloadUpdateCommand =>
+      (super.noSuchMethod(
+        Invocation.getter(#downloadUpdateCommand),
+        returnValue: _FakeCommand_0<_i13.UpdateInfo, String>(
+          this,
+          Invocation.getter(#downloadUpdateCommand),
+        ),
+        returnValueForMissingStub: _FakeCommand_0<_i13.UpdateInfo, String>(
+          this,
+          Invocation.getter(#downloadUpdateCommand),
+        ),
+      ) as _i2.Command<_i13.UpdateInfo, String>);
+
+  @override
+  _i2.Command<String, void> get installUpdateCommand => (super.noSuchMethod(
+        Invocation.getter(#installUpdateCommand),
+        returnValue: _FakeCommand_0<String, void>(
+          this,
+          Invocation.getter(#installUpdateCommand),
+        ),
+        returnValueForMissingStub: _FakeCommand_0<String, void>(
+          this,
+          Invocation.getter(#installUpdateCommand),
+        ),
+      ) as _i2.Command<String, void>);
+
+  @override
+  set load(_i2.Command<dynamic, dynamic>? _load) => super.noSuchMethod(
+        Invocation.setter(
+          #load,
+          _load,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
         ),
         returnValueForMissingStub: null,
       );

--- a/test/unit/domain/use_cases/app_update_use_case_test.dart
+++ b/test/unit/domain/use_cases/app_update_use_case_test.dart
@@ -8,6 +8,7 @@ import 'package:readeck_app/domain/models/update/update_info.dart';
 import 'package:readeck_app/domain/use_cases/app_update_use_case.dart';
 import 'package:result_dart/result_dart.dart';
 
+import '../../../helpers/test_logger_helper.dart';
 import 'app_update_use_case_test.mocks.dart';
 
 @GenerateMocks([DownloadService, AppInstallerService])
@@ -25,15 +26,18 @@ void main() {
     late MockAppInstallerService mockInstallerService;
     late Logger mockLogger;
 
+    setupTestGroupLogging();
+
     setUp(() {
       // Create mock services
       mockDownloadService = MockDownloadService();
       mockInstallerService = MockAppInstallerService();
 
-      // Create a mock logger for testing to avoid appLogger dependency
+      // Use the test logger which only outputs on failure
       mockLogger = Logger(
-        printer: PrettyPrinter(),
-        output: null, // Don't output during tests
+        printer: SimpleTestPrinter(),
+        output: MultiOutput([]),
+        level: Level.off,
       );
 
       // Setup default stubs for all required methods
@@ -302,14 +306,16 @@ void main() {
 
     group('Integration Tests', () {
       test('multiple use case instances should work independently', () {
-        // Create mock loggers for this test
+        // Create silent test loggers
         final mockLogger1 = Logger(
-          printer: PrettyPrinter(),
-          output: null, // Don't output during tests
+          printer: SimpleTestPrinter(),
+          output: MultiOutput([]),
+          level: Level.off,
         );
         final mockLogger2 = Logger(
-          printer: PrettyPrinter(),
-          output: null, // Don't output during tests
+          printer: SimpleTestPrinter(),
+          output: MultiOutput([]),
+          level: Level.off,
         );
 
         final useCase1 = AppUpdateUseCase(


### PR DESCRIPTION
## 概述

修复了 FloatingActionButton 在页面切换后滚动隐藏功能失效的问题。

Closes #85

## 问题背景

FAB 的下滑隐藏功能在从未读页切换到每日阅读页后会失效，影响用户体验的一致性。

## 解决方案

### 🔧 架构重构

**从全局 Provider 模式改为页面级管理**
- ❌ 旧架构：使用 `ScrollControllerProvider` 全局共享 ScrollController
- ✅ 新架构：每个页面独立管理自己的 ScrollController 和 FAB

### 🎯 关键修改

1. **移除全局 Provider 依赖**
   - 删除 `ScrollControllerProvider` 类
   - `MainLayout` 直接接受 `scrollController` 参数

2. **优化 ScrollController 绑定**
   - FAB 组件在 `build` 方法中直接绑定监听器
   - 避免异步时机问题，确保监听器正常工作

3. **统一页面架构**
   - 所有书签列表页面采用相同的 FAB 管理模式
   - 确保功能一致性和可维护性

## 技术细节

### 修改的文件

#### 核心组件
- `lib/ui/core/ui/bookmark_list_fab.dart` - FAB 组件重构
- `lib/ui/core/main_layout.dart` - 移除 Provider，支持直接传参

#### 页面层
- `lib/ui/daily_read/widgets/daily_read_screen.dart` - 自管理 FAB
- `lib/ui/bookmarks/widget/unarchived_screen.dart` - 添加 FAB 支持
- `lib/ui/bookmarks/widget/reading_screen.dart` - 添加 FAB 支持  
- `lib/ui/bookmarks/widget/archived_screen.dart` - 添加 FAB 支持
- `lib/ui/bookmarks/widget/marked_screen.dart` - 添加 FAB 支持

#### 架构支持
- `lib/ui/bookmarks/widget/bookmark_list_screen.dart` - 支持外部 ScrollController
- `lib/routing/router.dart` - 更新路由配置，避免双重包装

### 关键代码实现

**FAB 组件监听器绑定**
```dart
@override
Widget build(BuildContext context) {
  // 简单直接地绑定监听器
  if (widget.scrollController != null) {
    widget.scrollController!.removeListener(_onScroll);
    widget.scrollController!.addListener(_onScroll);
  }
  
  return ScaleTransition(
    scale: _animation,
    child: FloatingActionButton(
      onPressed: _onFabPressed,
      tooltip: '添加书签',
      child: const Icon(Icons.add),
    ),
  );
}
```

**页面级管理模式**
```dart
class _UnarchivedScreenState extends State<UnarchivedScreen> {
  late final ScrollController _scrollController;

  @override
  void initState() {
    super.initState();
    _scrollController = ScrollController();
  }

  @override
  Widget build(BuildContext context) {
    return MainLayout(
      title: '未读',
      showFab: true,
      scrollController: _scrollController,
      child: BookmarkListScreen(
        viewModel: widget.viewModel,
        scrollController: _scrollController,
        // ...
      ),
    );
  }
}
```

## 测试验证

### ✅ 功能验证
- [x] 每日阅读页面 FAB 滚动功能正常
- [x] 未读页面 FAB 滚动功能正常  
- [x] 阅读中页面 FAB 滚动功能正常
- [x] 已归档页面 FAB 滚动功能正常
- [x] 收藏页面 FAB 滚动功能正常
- [x] 页面切换后功能保持正常

### ✅ 代码质量
- [x] Flutter analyze 通过（无警告和错误）
- [x] 代码格式化符合项目规范
- [x] 遵循项目架构模式

## 影响评估

### 🎉 正面影响
- 修复了影响用户体验的滚动功能问题
- 统一了所有书签列表页面的 FAB 行为
- 简化了架构，提高了可维护性
- 消除了时机竞态条件，提升了稳定性

### ⚠️ 潜在风险
- **低风险**：从全局 Provider 改为页面级管理，改动较大但架构更清晰
- **缓解措施**：充分测试所有相关页面，确保功能正常

## 检查清单

- [x] 问题修复验证
- [x] 所有相关页面功能正常
- [x] 代码审查通过
- [x] Flutter analyze 无问题
- [x] 遵循项目编码规范
- [x] 关联相应的 issue (#85)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 新功能
  * 部分书签页与“每日阅读”页采用主布局呈现页面标题并支持与列表滚动联动的悬浮操作按钮（FAB）。
* 修复
  * 优化 FAB 可见性逻辑：更稳健的上/下滚动与靠近顶部判定，减少误触发与抖动。
  * 某些书签类路由现在由自管理路线处理，不再通过主布局包裹，FAB 展示行为随之变化。
* 重构
  * 简化滚动控制与依赖注入，移除共享提供者，提升稳定性与可维护性。
* 测试
  * 更新并扩展测试与模拟以适配新的页面结构与依赖变更。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->